### PR TITLE
added channel Id on create post

### DIFF
--- a/mockrest/guilds.go
+++ b/mockrest/guilds.go
@@ -222,7 +222,9 @@ func (roundTripper *RoundTripper) guildChannelsPOST(w http.ResponseWriter, r *ht
 		return
 	}
 
-	ch := &discordgo.Channel{}
+	ch := &discordgo.Channel{
+		ID: randString(),
+	}
 
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()


### PR DESCRIPTION
before, channels were created with blank ids and were subsequently overwritten by new ones with blank ids